### PR TITLE
check for secp256k1.HAS_RECOVERABLE

### DIFF
--- a/golem_sci/__init__.py
+++ b/golem_sci/__init__.py
@@ -1,3 +1,25 @@
+def _check_secp256k1_recovery():
+    """
+    secp256k1 library has optional "ECDSA pubkey recovery module", which is
+    not built by default (requires ./configure --enable-module-recovery).
+
+    secp256k1-py python module in setup.py searches for the secp256k1 library
+    and uses it. If it's not installed, it builds one by itself, with pubkey
+    recovery module enabled.
+
+    Ethereum python module requires recovery module enabled in secp256k1-py.
+    """
+
+    import secp256k1
+    if not secp256k1.HAS_RECOVERABLE:
+        raise NotImplementedError(
+            "secp256k1 is built without recovery module. "
+            "See https://github.com/golemfactory/golem/issues/2168")
+
+
+_check_secp256k1_recovery()
+
+
 from .factory import (  # noqa
     new_sci,
     new_sci_ipc,


### PR DESCRIPTION
Fixes https://github.com/golemfactory/golem/issues/2168

With this change, if secp256k1 library is available and compiled without recovery module, golemapp.py will just break:
```
$ ./golemapp.py                                                                                                                       
Traceback (most recent call last):
  File "./golemapp.py", line 26, in <module>
    from golem.node import Node  # noqa
  File "/home/etam/code/github/golemfactory/golem/secp256k1_recovery_not_enabled/golem/node.py", line 8, in <module>
    from golem.client import Client
  File "/home/etam/code/github/golemfactory/golem/secp256k1_recovery_not_enabled/golem/client.py", line 64, in <module>
    from golem.transactions.ethereum.ethereumtransactionsystem import \
  File "/home/etam/code/github/golemfactory/golem/secp256k1_recovery_not_enabled/golem/transactions/ethereum/ethereumtransactionsystem.py", line 13, in <module>                                                                                                       
    import golem_sci
  File "/home/etam/code/github/golemfactory/golem-smart-contracts-interface/master/golem_sci/__init__.py", line 7, in <module>
    _check_secp256k1_recovery()
  File "/home/etam/code/github/golemfactory/golem-smart-contracts-interface/master/golem_sci/__init__.py", line 4, in _check_secp256k1_recovery                                                                                                                        
    raise NotImplementedError("secp256k1.HAS_RECOVERABLE is False")
NotImplementedError: secp256k1.HAS_RECOVERABLE is False
```
This is better, because it completely prevents golemapp from running with a clear message. I don't think anything more sophisticated is required.