### PR TITLE
GNTConverter

### DIFF
--- a/golem_sci/gntconverter.py
+++ b/golem_sci/gntconverter.py
@@ -3,13 +3,15 @@ import logging
 
 from ethereum.utils import denoms
 
+from .interface import SmartContractsInterface
+
 logger = logging.getLogger("golem_sci.gnt_converter")
 
 
 class GNTConverter:
     REQUIRED_CONFS = 2
 
-    def __init__(self, sci):
+    def __init__(self, sci: SmartContractsInterface):
         self._sci = sci
         self._gate_address: Optional[str] = None
         self._ongoing_conversion: bool = False

--- a/golem_sci/gntconverter.py
+++ b/golem_sci/gntconverter.py
@@ -1,0 +1,78 @@
+from typing import Optional
+import logging
+
+from ethereum.utils import denoms
+
+logger = logging.getLogger("golem_sci.gnt_converter")
+
+
+class GNTConverter:
+    REQUIRED_CONFS = 2
+
+    def __init__(self, sci):
+        self._sci = sci
+        self._gate_address: Optional[str] = None
+        self._ongoing_conversion: bool = False
+
+    def convert(self, amount: int):
+        if self.is_converting():
+            # This isn't a technical restriction but rather a simplification
+            # for our use case
+            raise Exception('Can process only single conversion at once')
+
+        self._ongoing_conversion = True
+
+        self._ensure_gate(amount)
+
+    def is_converting(self) -> bool:
+        return self._ongoing_conversion
+
+    def _ensure_gate(self, amount: int) -> None:
+        # First step is opening the gate if it's not already opened
+        if self._gate_address is None:
+            self._gate_address = self._sci.get_gate_address()
+            if self._gate_address and int(self._gate_address, 16) == 0:
+                self._gate_address = None
+
+        if self._gate_address is None:
+            tx_hash = self._sci.open_gate()
+            logger.info('Opening gate %s', tx_hash)
+            self._sci.on_transaction_confirmed(
+                tx_hash,
+                self.REQUIRED_CONFS,
+                lambda _: self._ensure_gate(amount),
+            )
+            return
+
+        self._transfer_to_gate(amount)
+
+    def _transfer_to_gate(self, amount: int) -> None:
+        # Second step is to transfer the desired amount of GNT to the gate
+        tx_hash = self._sci.transfer_gnt(
+            self._gate_address,
+            amount,
+        )
+        logger.info(
+            'Transfering %f GNT to the gate %s',
+            amount / denoms.ether,
+            tx_hash,
+        )
+        self._sci.on_transaction_confirmed(
+            tx_hash,
+            self.REQUIRED_CONFS,
+            lambda _: self._transfer_from_gate(),
+        )
+
+    def _transfer_from_gate(self) -> None:
+        # Last step is to transfer GNT from the gate to GNTB contract
+        tx_hash = self._sci.transfer_from_gate()
+        logger.info('Transfering GNT from the gate %s', tx_hash)
+        self._sci.on_transaction_confirmed(
+            tx_hash,
+            self.REQUIRED_CONFS,
+            lambda _: self._conversion_finalized(),
+        )
+
+    def _conversion_finalized(self) -> None:
+        self._ongoing_conversion = False
+        logger.info('Conversion has been finalized')

--- a/tests/test_gntconverter.py
+++ b/tests/test_gntconverter.py
@@ -1,0 +1,38 @@
+from unittest import mock, TestCase
+
+from golem_sci.gntconverter import GNTConverter
+
+
+class GNTConverterTest(TestCase):
+    def setUp(self):
+        self.sci = mock.Mock()
+        self.converter = GNTConverter(self.sci)
+
+    def test_flow(self):
+        assert not self.converter.is_converting()
+
+        amount = 123
+        gate_address = '0xdead'
+        self.sci.get_gate_address.return_value = None
+        pending_tx_cb = []
+        self.sci.on_transaction_confirmed.side_effect = \
+            lambda hash, confs, cb: pending_tx_cb.append(cb)
+
+        self.converter.convert(amount)
+        assert self.converter.is_converting()
+        self.sci.open_gate.assert_called_once_with()
+        assert len(pending_tx_cb) == 1
+
+        self.sci.get_gate_address.return_value = gate_address
+        pending_tx_cb[0](mock.Mock())
+        assert self.converter.is_converting()
+        self.sci.transfer_gnt.assert_called_once_with(gate_address, amount)
+        assert len(pending_tx_cb) == 2
+
+        pending_tx_cb[1](mock.Mock())
+        assert self.converter.is_converting()
+        self.sci.transfer_from_gate.assert_called_once_with()
+        assert len(pending_tx_cb) == 3
+
+        pending_tx_cb[2](mock.Mock())
+        assert not self.converter.is_converting()


### PR DESCRIPTION
Move GNTConverter from Golem core. Also it's implemented using callbacks on confirmed transactions instead of constant pulling.