### PR TITLE
Throw on invalid transaction

### DIFF
--- a/golem_sci/implementation.py
+++ b/golem_sci/implementation.py
@@ -3,6 +3,7 @@ import threading
 import time
 from typing import Callable, List, Optional
 
+from ethereum.exceptions import InvalidTransaction
 from ethereum.utils import zpad, int_to_big_endian
 from ethereum.transactions import Transaction
 from eth_utils import decode_hex, encode_hex
@@ -283,6 +284,8 @@ class SCIImplementation(SmartContractsInterface):
         self._tx_sign(tx)
         try:
             return self._geth_client.send(tx)
+        except InvalidTransaction:
+            raise
         except Exception:
             with self._failed_tx_requests_lock:
                 self._failed_tx_requests.append(tx)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,8 +7,8 @@ from golem_sci.factory import new_sci
 
 from web3 import Web3
 from web3.providers.eth_tester import EthereumTesterProvider
+from ethereum.exceptions import InvalidTransaction
 from ethereum.keys import privtoaddr
-from ethereum.tester import TransactionFailed
 from eth_tester import EthereumTester
 from eth_utils import decode_hex, encode_hex, denoms
 
@@ -242,6 +242,13 @@ class IntegrationTest(TestCase):
     def _time_travel(self, period: int):
         current_ts = self.eth_tester.get_block_by_number('pending')['timestamp']
         self.eth_tester.time_travel(current_ts + period)
+
+    def test_invalid_transaction(self):
+        recipient = '0x' + 40 * 'e'
+        assert self.user_sci.get_eth_balance(recipient) == 0
+        amount = self.user_sci.get_eth_balance(self.user_sci.get_eth_address())
+        with self.assertRaises(InvalidTransaction):
+            self.user_sci.transfer_eth(recipient, amount)
 
     def test_transfer_eth(self):
         recipient = '0x' + 40 * 'e'


### PR DESCRIPTION
In case of `InvalidTransaction` the transaction didn't make it to the pending pool at all so no need for retries. 