### PR TITLE
Better transactions management

### DIFF
--- a/golem_sci/__init__.py
+++ b/golem_sci/__init__.py
@@ -27,6 +27,8 @@ from .factory import (  # noqa
     new_sci_rpc,
 )
 
+from .gntconverter import GNTConverter  # noqa
+
 from .structs import (  # noqa
     Block,
     Payment,

--- a/golem_sci/client.py
+++ b/golem_sci/client.py
@@ -103,11 +103,7 @@ class Client(object):
         set with web3.eth.defaultBlock
         :return: Balance
         """
-        try:
-            return self.web3.eth.getBalance(account, block)
-        except ValueError as e:
-            logger.error("Ethereum RPC: {}".format(e))
-            return None
+        return self.web3.eth.getBalance(account, block)
 
     def get_gas_price(self) -> int:
         return self.web3.eth.gasPrice

--- a/golem_sci/gntconverter.py
+++ b/golem_sci/gntconverter.py
@@ -9,8 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 class GNTConverter:
-    REQUIRED_CONFS = 2
-
     def __init__(self, sci: SmartContractsInterface) -> None:
         self._sci = sci
         self._gate_address: Optional[str] = None
@@ -85,7 +83,6 @@ class GNTConverter:
         logger.info('Opening gate %s', tx_hash)
         self._sci.on_transaction_confirmed(
             tx_hash,
-            self.REQUIRED_CONFS,
             lambda _: self._process(),
         )
 
@@ -108,7 +105,6 @@ class GNTConverter:
             self._process()
         self._sci.on_transaction_confirmed(
             tx_hash,
-            self.REQUIRED_CONFS,
             on_confirmed,
         )
 
@@ -117,7 +113,6 @@ class GNTConverter:
         logger.info('Transfering GNT from the gate %s', tx_hash)
         self._sci.on_transaction_confirmed(
             tx_hash,
-            self.REQUIRED_CONFS,
             lambda _: self._process(),
         )
 

--- a/golem_sci/interface.py
+++ b/golem_sci/interface.py
@@ -29,23 +29,23 @@ class SmartContractsInterface(object, metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def get_eth_balance(self, address: str) -> Optional[int]:
+    def get_eth_balance(self, address: str) -> int:
         """
-        Returns eth balance in wei or None is case of issues.
-        """
-        pass
-
-    @abc.abstractmethod
-    def get_gnt_balance(self, address: str) -> Optional[int]:
-        """
-        Returns GNT balance in wei or None is case of issues.
+        Returns eth balance in wei.
         """
         pass
 
     @abc.abstractmethod
-    def get_gntb_balance(self, address: str) -> Optional[int]:
+    def get_gnt_balance(self, address: str) -> int:
         """
-        Returns GNTB balance in wei or None is case of issues.
+        Returns GNT balance in wei.
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_gntb_balance(self, address: str) -> int:
+        """
+        Returns GNTB balance in wei.
         """
         pass
 
@@ -80,8 +80,7 @@ class SmartContractsInterface(object, metaclass=abc.ABCMeta):
             self,
             address: str,
             from_block: int,
-            cb: Callable[[BatchTransferEvent], None],
-            required_confs: int) -> None:
+            cb: Callable[[BatchTransferEvent], None]) -> None:
         """
         Every time a BatchTransfer event happens callback will be called
         if the recipient equals to the input address and the block has been
@@ -93,7 +92,6 @@ class SmartContractsInterface(object, metaclass=abc.ABCMeta):
     def on_transaction_confirmed(
             self,
             tx_hash: str,
-            required_confs: int,
             cb: Callable[[TransactionReceipt], None]) -> None:
         """
         Will invoke callback after the transaction has been confirmed
@@ -153,12 +151,15 @@ class SmartContractsInterface(object, metaclass=abc.ABCMeta):
     # Transaction
     @abc.abstractmethod
     def open_gate(self) -> str:
+        """
+        Creates the gate required for GNT-GNTB conversion.
+        """
         pass
 
     @abc.abstractmethod
-    def get_gate_address(self) -> str:
+    def get_gate_address(self) -> Optional[str]:
         """
-        Returns Ethereum address
+        Returns Ethereum address of the gate or None if it doesn't exist yet.
         """
         pass
 
@@ -166,7 +167,7 @@ class SmartContractsInterface(object, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def transfer_from_gate(self) -> str:
         """
-        Final step which convert the value of the gate to GNTB
+        Final step which convert the value of the gate to GNTB.
         """
         pass
 

--- a/golem_sci/transactionsstorage.py
+++ b/golem_sci/transactionsstorage.py
@@ -1,0 +1,140 @@
+import json
+import logging
+
+from abc import abstractmethod
+from pathlib import Path
+from typing import ClassVar, Dict, List
+
+from eth_utils import decode_hex, encode_hex
+from ethereum.transactions import Transaction
+from hexbytes import HexBytes
+
+logger = logging.getLogger(__name__)
+
+
+class TransactionsStorage:
+    @abstractmethod
+    def get_nonce(self) -> int:
+        """
+        Returns the nonce for the next transaction.
+        """
+        pass
+
+    @abstractmethod
+    def get_all_tx(self) -> List[Transaction]:
+        """
+        Returns the list of all transactions.
+        """
+        pass
+
+    @abstractmethod
+    def put_tx_and_inc_nonce(self, tx: Transaction) -> None:
+        """
+        Save a valid transaction and increase the nonce.
+        """
+        pass
+
+    @abstractmethod
+    def remove_tx(self, nonce: int) -> None:
+        """
+        Remove the transaction after it's been confirmed and doesn't have
+        to be tracked anymore.
+        """
+        pass
+
+    @abstractmethod
+    def revert_last_tx(self) -> None:
+        """
+        Remove the last transaction that was added.
+        This shouldn't be ever called if everything is being used correctly,
+        i.e. we don't try to send invalid transactions.
+        """
+        pass
+
+
+class JsonTransactionsStorage(TransactionsStorage):
+    FILENAME: ClassVar[str] = 'transactions.json'
+
+    def __init__(self, datadir: Path, nonce: int) -> None:
+        self._filepath = datadir / self.FILENAME
+        self._data = {}
+        if self._filepath.exists():
+            with open(self._filepath) as f:
+                self._data = json.load(f)
+            if 'tx' in self._data:
+                self._data['tx'] = \
+                    {int(nonce): tx for nonce, tx in self._data['tx'].items()}
+        if 'nonce' not in self._data:
+            logger.info('Initiating TransactionStorage with nonce %d', nonce)
+            self._data['nonce'] = nonce
+            self._data['tx'] = {}
+            self._save(self._data)
+        elif self._data['nonce'] != nonce:
+            raise Exception(
+                'TransactionStorage initialization failed. Found '
+                'nonce={} while current nonce is={}'.format(
+                    self._data['nonce'], nonce))
+
+    def get_nonce(self) -> int:
+        return self._data['nonce']
+
+    def get_all_tx(self) -> List[Transaction]:
+        def convert(tx):
+            return Transaction(
+                nonce=tx['nonce'],
+                gasprice=tx['gasprice'],
+                startgas=tx['startgas'],
+                to=tx['to'],
+                value=tx['value'],
+                data=decode_hex(tx['data']),
+                v=tx['v'],
+                r=tx['r'],
+                s=tx['s'],
+            )
+        return [convert(tx) for tx in self._data['tx'].values()]
+
+    def put_tx_and_inc_nonce(self, tx: Transaction) -> None:
+        if tx.nonce != self._data['nonce']:
+            raise Exception(
+                'Transaction nonce does not match. Current={}, tx={}'.format(
+                    self._data['nonce'], tx.nonce))
+        logger.info(
+            'Saving transaction %s, nonce=%d',
+            encode_hex(tx.hash),
+            tx.nonce,
+        )
+        # Use temporary copy because we don't want to modify the state if
+        # writing to the file fails
+        new_data = dict(self._data)
+        new_data['nonce'] = tx.nonce + 1
+        new_data['tx'][tx.nonce] = {
+            'nonce': tx.nonce,
+            'gasprice': tx.gasprice,
+            'startgas': tx.startgas,
+            'to': HexBytes(tx.to).hex(),
+            'value': tx.value,
+            'data': HexBytes(tx.data).hex(),
+            'v': tx.v,
+            'r': tx.r,
+            's': tx.s,
+        }
+        self._save(new_data)
+        self._data = new_data
+
+    def remove_tx(self, nonce: int) -> None:
+        logger.info('Removing transaction nonce=%d', nonce)
+        new_data = dict(self._data)
+        del new_data['tx'][nonce]
+        self._save(new_data)
+        self._data = new_data
+
+    def revert_last_tx(self) -> None:
+        new_data = dict(self._data)
+        new_data['nonce'] -= 1
+        del new_data['tx'][new_data['nonce']]
+        self._save(new_data)
+        self._data = new_data
+
+    def _save(self, data: Dict) -> None:
+        with open(self._filepath, 'w') as f:
+            json.dump(data, f)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,5 +1,6 @@
 import unittest.mock as mock
 import unittest
+from pathlib import Path
 
 from hexbytes import HexBytes
 
@@ -14,7 +15,7 @@ from golem_sci.factory import (
 )
 
 
-class SCIImplementationTest(unittest.TestCase):
+class FactoryTest(unittest.TestCase):
     @mock.patch('golem_sci.factory._ensure_connection')
     @mock.patch('golem_sci.factory._ensure_geth_version')
     @mock.patch('golem_sci.factory._ensure_genesis')
@@ -31,14 +32,17 @@ class SCIImplementationTest(unittest.TestCase):
         eth_address = '0xdeafbeef'
         web3 = mock.MagicMock()
         web3.middleware_stack.__iter__.return_value = []
+        datadir = Path('/nonexistent')
 
-        new_sci(web3, eth_address, tx_sign, chain=RINKEBY)
+        with mock.patch('golem_sci.factory.JsonTransactionsStorage'):
+            new_sci(datadir, web3, eth_address, tx_sign, chain=RINKEBY)
         ensure_connection.assert_called_once_with(web3)
         ensure_geth_version.assert_called_once_with(web3)
         ensure_genesis.assert_called_once_with(web3, RINKEBY)
         sci_init.assert_called_once_with(
             mock.ANY,
             eth_address,
+            mock.ANY,
             mock.ANY,
             tx_sign,
         )

--- a/tests/test_gntconverter.py
+++ b/tests/test_gntconverter.py
@@ -20,7 +20,7 @@ class GNTConverterTest(TestCase):
         self.sci.get_gate_address.return_value = None
         pending_tx_cb = []
         self.sci.on_transaction_confirmed.side_effect = \
-            lambda hash, confs, cb: pending_tx_cb.append(cb)
+            lambda hash, cb: pending_tx_cb.append(cb)
 
         converter.convert(amount)
         assert converter.is_converting()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,64 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from ethereum.transactions import Transaction
+
+from golem_sci.transactionsstorage import JsonTransactionsStorage
+
+
+def _make_signed_tx(nonce: int):
+    tx = Transaction(
+        startgas=21000,
+        gasprice=10**9,
+        value=10,
+        to='0x' + 40 * '0',
+        data=b'',
+        nonce=nonce,
+    )
+    tx.sign(os.urandom(32))
+    return tx
+
+
+class TransactionsStorageTest(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = Path(tempfile.mkdtemp())
+        self.storage = JsonTransactionsStorage(self.tempdir, 0)
+
+    def test_wrong_tx_nonce(self):
+        assert self.storage.get_nonce() == 0
+        with self.assertRaisesRegex(Exception, 'nonce does not match'):
+            self.storage.put_tx_and_inc_nonce(_make_signed_tx(1))
+
+    def test_put_get_remove(self):
+        tx = _make_signed_tx(0)
+        self.storage.put_tx_and_inc_nonce(tx)
+        assert self.storage.get_nonce() == 1
+        transactions = self.storage.get_all_tx()
+        assert len(transactions) == 1
+        assert transactions[0] == tx
+
+        self.storage.remove_tx(0)
+        assert self.storage.get_nonce() == 1
+        transactions = self.storage.get_all_tx()
+        assert len(transactions) == 0
+
+    def test_reload(self):
+        tx = _make_signed_tx(0)
+        self.storage.put_tx_and_inc_nonce(tx)
+        self.storage = JsonTransactionsStorage(self.tempdir, 1)
+        assert self.storage.get_nonce() == 1
+        transactions = self.storage.get_all_tx()
+        assert len(transactions) == 1
+        assert transactions[0] == tx
+
+        self.storage.remove_tx(0)
+        self.storage = JsonTransactionsStorage(self.tempdir, 1)
+        assert self.storage.get_nonce() == 1
+        transactions = self.storage.get_all_tx()
+        assert len(transactions) == 0
+
+    def test_wrong_inital_nonce(self):
+        with self.assertRaisesRegex(Exception, 'initialization failed'):
+            self.storage = JsonTransactionsStorage(self.tempdir, 1)


### PR DESCRIPTION
- transactions to be sent are saved on the disk
- they are re-broadcasted anytime they go missing from the tx pool
- they are removed after being confirmed
- all readonly operations are reading the state from `REQUIRED_CONFS` blocks ago
- the module is keeping track of the reserved ETH for all non yet confirmed transactions

Resolves #28