### PR TITLE
Explicit blockchain monitor started flag

### DIFF
--- a/golem_sci/implementation.py
+++ b/golem_sci/implementation.py
@@ -496,7 +496,7 @@ class SCIImplementation(SmartContractsInterface):
         )
         for step in steps:
             if self._monitor_started:
-                logger.debug("SCI monitor: step %s", )
+                logger.debug("SCI monitor: step %s", step.__name__)
                 step()
 
     def _update_gas_price(self) -> None:

--- a/golem_sci/implementation.py
+++ b/golem_sci/implementation.py
@@ -377,7 +377,6 @@ class SCIImplementation(SmartContractsInterface):
         self._monitor_started = False
         with self._monitor_cv:
             self._monitor_cv.notify()
-        logger.debug("SCI monitor: stopped")
 
     def _call(self, method) -> Any:
         return method.call(
@@ -474,6 +473,7 @@ class SCIImplementation(SmartContractsInterface):
 
     def _monitor_blockchain(self):
         logger.debug("SCI monitor: started")
+
         self._monitor_started = True
         with self._monitor_cv:
             while self._monitor_started \
@@ -482,6 +482,8 @@ class SCIImplementation(SmartContractsInterface):
                     self._monitor_blockchain_single()
                 except Exception as e:
                     logger.exception('Blockchain monitor exception: %r', e)
+
+        logger.debug("SCI monitor: stopped")
 
     def _monitor_blockchain_single(self):
         if not self._update_block_numbers():

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='Golem-Smart-Contracts-Interface',
-    version='1.10.3',
+    version='1.10.4',
     url='https://github.com/golemfactory/golem-smart-contracts-interface',
     maintainer='The Golem team',
     maintainer_email='tech@golem.network',

--- a/tests/integrationbase.py
+++ b/tests/integrationbase.py
@@ -213,6 +213,7 @@ class IntegrationBase(TestCase):
                 self.contract_addresses,
                 sign_tx_user,
             )
+            self.user_sci._monitor_started = True
 
             def sign_tx_concent(tx):
                 tx.sign(concent_privkey)

--- a/tests/test_implementation.py
+++ b/tests/test_implementation.py
@@ -45,6 +45,7 @@ class SCIImplementationTest(unittest.TestCase):
             self.contract_addresses,
             self.sign_tx,
             monitor=False)
+        self.sci._monitor_started = True
         self.gntb = self.contracts[self.contract_addresses[contracts.GNTB]]
 
     def test_eth_address(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -321,6 +321,7 @@ class TestIntegration(IntegrationBase):
                 tx_storage,
                 self.contract_addresses,
             )
+            self.user_sci._monitor_started = True
             self.concent_sci = None
         self._fund_account(self.user_sci.get_eth_address())
         self._wait_for_pending()


### PR DESCRIPTION
+ additional debug logs

generally, the purpose is to make exit from the monitor loop earlier that after the whole iteration -> which now, in case when timeouts are encountered, can take several minutes...