### PR TITLE
Moved sLogger hack to first import of ethereum

### DIFF
--- a/golem_sci/factory.py
+++ b/golem_sci/factory.py
@@ -4,23 +4,9 @@ import time
 from typing import Callable, Dict
 
 from distutils.version import StrictVersion
-from ethereum import slogging
 
-# ethereum.slogging and logging compatibility patch
-orig_getLogger = slogging.SManager.getLogger
-
-
-def monkey_patched_getLogger(*args, **kwargs):
-    orig_class = logging.getLoggerClass()
-    result = orig_getLogger(*args, **kwargs)
-    logging.setLoggerClass(orig_class)
-    return result
-
-
-slogging.SManager.getLogger = monkey_patched_getLogger
-
-# pylint: disable=wrong-import-position
-
+# this must be before any other ethereum imports
+from . import fix_logging
 from ethereum.transactions import Transaction
 from web3 import Web3, IPCProvider, HTTPProvider
 from web3.middleware import geth_poa_middleware

--- a/golem_sci/factory.py
+++ b/golem_sci/factory.py
@@ -4,6 +4,23 @@ import time
 from typing import Callable, Dict
 
 from distutils.version import StrictVersion
+from ethereum import slogging
+
+# ethereum.slogging and logging compatibility patch
+orig_getLogger = slogging.SManager.getLogger
+
+
+def monkey_patched_getLogger(*args, **kwargs):
+    orig_class = logging.getLoggerClass()
+    result = orig_getLogger(*args, **kwargs)
+    logging.setLoggerClass(orig_class)
+    return result
+
+
+slogging.SManager.getLogger = monkey_patched_getLogger
+
+# pylint: disable=wrong-import-position
+
 from ethereum.transactions import Transaction
 from web3 import Web3, IPCProvider, HTTPProvider
 from web3.middleware import geth_poa_middleware

--- a/golem_sci/fix_logging.py
+++ b/golem_sci/fix_logging.py
@@ -1,0 +1,22 @@
+import logging
+
+from ethereum import slogging
+
+
+# Monkey patch for ethereum.slogging.
+# SLogger aggressively mess up with python logger.
+# This patch is to settle down this.
+# It should be done before any SLogger is created.
+
+
+orig_getLogger = slogging.SManager.getLogger
+
+
+def monkey_patched_getLogger(*args, **kwargs):
+    orig_class = logging.getLoggerClass()
+    result = orig_getLogger(*args, **kwargs)
+    logging.setLoggerClass(orig_class)
+    return result
+
+
+slogging.SManager.getLogger = monkey_patched_getLogger


### PR DESCRIPTION
Moved this logger patch from golem-core to the first import of the ethereum sLogger

Without this patch a lot of loggers are configured to be WARNING level and not listen to the root logger level